### PR TITLE
test(sdk/elixir): add integration test for check support

### DIFF
--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -266,6 +266,46 @@ func (ElixirSuite) TestReqAdapter(ctx context.Context, t *testctx.T) {
 	require.Equal(t, "hello-from-req-adapter\n", out)
 }
 
+func (ElixirSuite) TestCheck(ctx context.Context, t *testctx.T) {
+	t.Run("list checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "failing-check")
+		require.Contains(t, out, "passing-container")
+		require.Contains(t, out, "failing-container")
+	})
+
+	t.Run("run passing checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExec("--progress=report", "check", "passing*")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Regexp(t, `passingCheck.*OK`, out)
+		require.Regexp(t, `passingContainer.*OK`, out)
+	})
+
+	t.Run("run failing checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExecFail("--progress=report", "check", "failing*")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Regexp(t, `failingCheck.*ERROR`, out)
+		require.Regexp(t, `failingContainer.*ERROR`, out)
+	})
+}
+
 func elixirModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/elixir", moduleName))

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.formatter.exs
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:dagger],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.gitattributes
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.gitattributes
@@ -1,0 +1,1 @@
+/dagger_sdk/** linguist-generated

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.gitignore
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.gitignore
@@ -1,0 +1,9 @@
+/dagger_sdk
+/_build
+/cover
+/deps
+/doc
+/erl_crash.dump
+/*.ez
+/template-*.tar
+/tmp

--- a/core/integration/testdata/modules/elixir/hello-with-checks/dagger.json
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "hello-with-checks",
+  "engineVersion": "v0.19.8",
+  "sdk": {
+    "source": "../../sdk/elixir"
+  }
+}

--- a/core/integration/testdata/modules/elixir/hello-with-checks/lib/hello_with_checks.ex
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/lib/hello_with_checks.ex
@@ -1,0 +1,31 @@
+defmodule HelloWithChecks do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "HelloWithChecks"
+
+  @check true
+  defn passing_check() :: Dagger.Void.t() do
+    :ok
+  end
+
+  @check true
+  defn failing_check() :: Dagger.Void.t() do
+    raise "this check always fails"
+  end
+
+  @check true
+  defn passing_container() :: Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("alpine:3")
+    |> Dagger.Container.with_exec(["sh", "-c", "exit 0"])
+  end
+
+  @check true
+  defn failing_container() :: Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("alpine:3")
+    |> Dagger.Container.with_exec(["sh", "-c", "exit 1"])
+  end
+end

--- a/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
@@ -1,4 +1,4 @@
-defmodule Template.MixProject do
+defmodule HelloWithChecks.MixProject do
   use Mix.Project
 
   def project do

--- a/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
@@ -1,0 +1,25 @@
+defmodule Template.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :hello_with_checks,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:dagger, path: "./dagger_sdk"}
+    ]
+  end
+end

--- a/core/integration/testdata/modules/elixir/hello-with-checks/mix.lock
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nestru": {:hex, :nestru, "1.0.1", "f02321db91b898da3d598c274f2ccba2c41ec5c50c942eabe900474dbfe4bce3", [:mix], [], "hexpm", "e4fbbd6d64b1c8cb37ef590a891f0b6b17b0b880c1c5ce2ac98de02c0ad7417e"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}


### PR DESCRIPTION
## Summary

- Adds a `TestCheck` integration test to `core/integration/module_elixir_test.go`
- Creates a new `hello-with-checks` Elixir test module with four check functions: `passing_check`, `failing_check`, `passing_container`, and `failing_container`
- Verifies that the `@check` attribute correctly marks Elixir functions as Dagger checks

## Test plan

- [x] `TestElixir/TestCheck/list_checks` — `dagger check -l` lists all four checks
- [x] `TestElixir/TestCheck/run_passing_checks` — `passing*` checks complete with OK status
- [x] `TestElixir/TestCheck/run_failing_checks` — `failing*` checks report ERROR status

https://claude.ai/code/session_01AtD2CbC3VTT2UqQfMhSXXg