### PR TITLE
sdk/elixir: compile defn/enum into __register__/1 and __dependencies__/0

### DIFF
--- a/sdk/elixir/lib/dagger/mod/enum.ex
+++ b/sdk/elixir/lib/dagger/mod/enum.ex
@@ -24,6 +24,11 @@ defmodule Dagger.Mod.Enum do
 
     {:ok, ast_type} = Code.string_to_quoted("@type t() :: #{atoms}")
 
+    # Pre-compute member registration data at compile time.
+    # Each entry: {display_value_string, doc_or_nil}
+    member_data = Enum.map(values, &extract_member_data/1)
+    camelized_name = Dagger.Mod.Helper.camelize(name)
+
     quote do
       use Dagger.Core.Base, kind: :enum, name: unquote(name)
 
@@ -33,7 +38,41 @@ defmodule Dagger.Mod.Enum do
       def __enum__(:keys), do: unquote(values)
 
       unquote_splicing(functions)
+
+      @doc false
+      def __register__(dag) do
+        Enum.reduce(
+          unquote(Macro.escape(member_data)),
+          dag |> Dagger.Client.type_def() |> Dagger.TypeDef.with_enum(unquote(camelized_name)),
+          fn {val, doc}, td ->
+            opts = [value: val] ++ if(doc, do: [description: doc], else: [])
+            Dagger.TypeDef.with_enum_member(td, val, opts)
+          end
+        )
+      end
+
+      @doc false
+      def __dependencies__(), do: []
     end
+  end
+
+  # Extract {value_string, doc_or_nil} from an enum value spec.
+  # value_string matches what Atom.to_string/1 gives for the key atom,
+  # matching the behaviour of the existing define_enum/2 in Dagger.Mod.Module.
+  defp extract_member_data(key) when is_atom(key) do
+    {Atom.to_string(key), nil}
+  end
+
+  defp extract_member_data({key, options}) when is_atom(key) and is_list(options) do
+    {Atom.to_string(key), options[:doc]}
+  end
+
+  defp extract_member_data({key, value}) when is_atom(key) and is_binary(value) do
+    {Atom.to_string(key), nil}
+  end
+
+  defp extract_member_data({key, {_value, options}}) when is_atom(key) and is_list(options) do
+    {Atom.to_string(key), options[:doc]}
   end
 
   defp defenum(key) when is_atom(key) do

--- a/sdk/elixir/lib/dagger/mod/module.ex
+++ b/sdk/elixir/lib/dagger/mod/module.ex
@@ -25,12 +25,24 @@ defmodule Dagger.Mod.Module do
   defp define(dag, dag_module, module) do
     case module.__kind__() do
       :object ->
-        dag_module
-        |> Dagger.Module.with_object(define_object(dag, module))
+        type_def =
+          if function_exported?(module, :__register__, 1) do
+            module.__register__(dag)
+          else
+            define_object(dag, module)
+          end
+
+        Dagger.Module.with_object(dag_module, type_def)
 
       :enum ->
-        dag_module
-        |> Dagger.Module.with_enum(define_enum(dag, module))
+        type_def =
+          if function_exported?(module, :__register__, 1) do
+            module.__register__(dag)
+          else
+            define_enum(dag, module)
+          end
+
+        Dagger.Module.with_enum(dag_module, type_def)
     end
   end
 

--- a/sdk/elixir/lib/dagger/mod/object.ex
+++ b/sdk/elixir/lib/dagger/mod/object.ex
@@ -167,24 +167,286 @@ defmodule Dagger.Mod.Object do
   end
 
   defmacro __before_compile__(env) do
-    if Module.get_attribute(env.module, :struct_declared) do
-      required_fields = Module.get_attribute(env.module, :required_fields) || []
-      optional_fields = Module.get_attribute(env.module, :optional_fields) || []
-      fields = required_fields ++ optional_fields
-      fields = Macro.escape(fields)
+    module = env.module
 
-      quote do
-        defimpl Nestru.Decoder do
-          def decode_fields_hint(_empty_struct, _context, _value) do
-            {:ok, Dagger.Mod.Object.decoder_hint(unquote(fields))}
+    decoder_impl =
+      if Module.get_attribute(module, :struct_declared) do
+        required_fields = Module.get_attribute(module, :required_fields) || []
+        optional_fields = Module.get_attribute(module, :optional_fields) || []
+        fields = required_fields ++ optional_fields
+        fields = Macro.escape(fields)
+
+        quote do
+          defimpl Nestru.Decoder do
+            def decode_fields_hint(_empty_struct, _context, _value) do
+              {:ok, Dagger.Mod.Object.decoder_hint(unquote(fields))}
+            end
           end
         end
+      else
+        quote do
+        end
       end
-    else
-      quote do
+
+    # Build compile-time registration data from accumulated attributes.
+    object_name = Module.get_attribute(module, :object_name)
+
+    # @function_compile_data accumulates in reverse; reverse to get definition order.
+    compile_data =
+      (Module.get_attribute(module, :function_compile_data) || [])
+      |> Enum.reverse()
+
+    # @field accumulates in reverse; reverse for definition order.
+    fields =
+      (Module.get_attribute(module, :field) || [])
+      |> List.flatten()
+      |> Enum.reverse()
+
+    # Compute direct dependencies at compile time.
+    deps = compute_deps(compile_data)
+
+    # Generate the __register__/1 body as quoted AST.
+    register_body = build_register_body(object_name, compile_data, fields, module)
+
+    dag_var = Macro.var(:dag, nil)
+
+    quote do
+      unquote(decoder_impl)
+
+      @doc false
+      def __register__(unquote(dag_var)) do
+        unquote(register_body)
+      end
+
+      @doc false
+      def __dependencies__() do
+        unquote(Macro.escape(deps))
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Compile-time helpers for __register__/1 and __dependencies__/0 generation
+  # ---------------------------------------------------------------------------
+
+  # Returns list of direct dependency modules (enums + object return types)
+  # computed from the accumulated @function_compile_data entries.
+  defp compute_deps(compile_data) do
+    compile_data
+    |> Enum.flat_map(fn {_name, _self, arg_defs, return_def, _cache, _doc, _deprecated} ->
+      arg_types = Enum.map(arg_defs, fn {_name, kw} -> Keyword.fetch!(kw, :type) end)
+      [return_def | arg_types]
+    end)
+    |> Enum.flat_map(&collect_dep_modules/1)
+    |> Enum.uniq()
+  end
+
+  defp collect_dep_modules({:list, inner}), do: collect_dep_modules(inner)
+  defp collect_dep_modules({:optional, inner}), do: collect_dep_modules(inner)
+  defp collect_dep_modules(primitive) when primitive in [:integer, :float, :boolean, :string],
+    do: []
+
+  defp collect_dep_modules(module) when is_atom(module) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :__kind__, 0) do
+      case module.__kind__() do
+        :object ->
+          # Only user-defined object modules (those using Dagger.Mod.Object) are
+          # tracked as dependencies; Dagger built-ins like Dagger.Container are not.
+          if function_exported?(module, :__object__, 1), do: [module], else: []
+
+        :enum ->
+          [module]
+
+        _ ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  # Build the AST for the __register__/1 function body.
+  defp build_register_body(object_name, compile_data, fields, module) do
+    dag = Macro.var(:dag, nil)
+    camelized = Dagger.Mod.Helper.camelize(object_name)
+
+    # Separate constructor (:init) from regular functions.
+    {constructors, regular_fns} =
+      Enum.split_with(compile_data, fn {name, _, _, _, _, _, _} -> name == :init end)
+
+    # Base TypeDef expression.
+    base =
+      quote do
+        unquote(dag)
+        |> Dagger.Client.type_def()
+        |> Dagger.TypeDef.with_object(
+          unquote(camelized),
+          case Dagger.Mod.Object.get_module_deprecated(unquote(module)) do
+            nil -> []
+            {key, val} -> [{key, val}]
+          end
+        )
+      end
+
+    # Pipe in each field.
+    with_fields =
+      Enum.reduce(fields, base, fn {fname, field_def}, acc ->
+        type = field_def.type
+        field_opts = build_field_opts(field_def)
+
+        quote do
+          unquote(acc)
+          |> Dagger.TypeDef.with_field(
+            unquote(fname),
+            Dagger.Mod.Object.TypeDef.define(unquote(dag), unquote(Macro.escape(type))),
+            unquote(field_opts)
+          )
+        end
+      end)
+
+    # Pipe in each regular function.
+    with_fns =
+      Enum.reduce(regular_fns, with_fields, fn fn_entry, acc ->
+        fn_ast = build_function_ast(dag, fn_entry, module)
+
+        quote do
+          unquote(acc)
+          |> Dagger.TypeDef.with_function(unquote(fn_ast))
+        end
+      end)
+
+    # Pipe in constructor if present.
+    case constructors do
+      [] ->
+        with_fns
+
+      [fn_entry] ->
+        fn_ast = build_function_ast(dag, fn_entry, module)
+
+        quote do
+          unquote(with_fns)
+          |> Dagger.TypeDef.with_constructor(unquote(fn_ast))
+        end
+    end
+  end
+
+  defp build_field_opts(field_def) do
+    opts = []
+    opts = if field_def.deprecated, do: Keyword.put(opts, :deprecated, field_def.deprecated), else: opts
+    opts = if field_def.doc, do: Keyword.put(opts, :description, field_def.doc), else: opts
+    Macro.escape(opts)
+  end
+
+  # Build the AST for a single Dagger.Function.
+  defp build_function_ast(dag, {fn_name, _has_self, arg_defs, return_def, cache, doc_raw, deprecated_raw}, module) do
+    camelized = Dagger.Mod.Helper.camelize(fn_name)
+    {doc, doc_deprecated} = normalize_doc_attr(doc_raw)
+    deprecated = normalize_deprecated_attr(deprecated_raw) || doc_deprecated
+
+    # Build the return TypeDef expression.
+    return_type_ast =
+      quote do
+        Dagger.Mod.Object.TypeDef.define(unquote(dag), unquote(Macro.escape(return_def)))
+      end
+
+    base_fn =
+      quote do
+        unquote(dag)
+        |> Dagger.Client.function(unquote(camelized), unquote(return_type_ast))
+      end
+
+    with_doc =
+      if doc do
+        quote do
+          unquote(base_fn) |> Dagger.Function.with_description(unquote(doc))
+        end
+      else
+        base_fn
+      end
+
+    with_deprecated =
+      if deprecated do
+        quote do
+          unquote(with_doc) |> Dagger.Function.with_deprecated(reason: unquote(deprecated))
+        end
+      else
+        with_doc
+      end
+
+    with_cache = apply_cache_ast(with_deprecated, cache)
+
+    # Pipe in each argument.
+    Enum.reduce(arg_defs, with_cache, fn {arg_name, arg_kw}, acc ->
+      type = Keyword.fetch!(arg_kw, :type)
+      arg_opts = build_arg_opts(arg_kw)
+
+      quote do
+        unquote(acc)
+        |> Dagger.Function.with_arg(
+          unquote(arg_name),
+          Dagger.Mod.Object.TypeDef.define(unquote(dag), unquote(Macro.escape(type))),
+          unquote(arg_opts)
+        )
+      end
+    end)
+  end
+
+  defp build_arg_opts(arg_kw) do
+    opts =
+      arg_kw
+      |> Keyword.take([:doc, :default, :default_path, :ignore, :deprecated])
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
+      |> Enum.map(fn
+        {:doc, v} -> {:description, v}
+        {:default, v} -> {:default_value, Jason.encode!(v)}
+        pair -> pair
+      end)
+
+    Macro.escape(opts)
+  end
+
+  defp apply_cache_ast(ast, nil), do: ast
+
+  defp apply_cache_ast(ast, :never) do
+    quote do
+      unquote(ast)
+      |> Dagger.Function.with_cache_policy(Dagger.FunctionCachePolicy.never())
+    end
+  end
+
+  defp apply_cache_ast(ast, :per_session) do
+    quote do
+      unquote(ast)
+      |> Dagger.Function.with_cache_policy(Dagger.FunctionCachePolicy.per_session())
+    end
+  end
+
+  defp apply_cache_ast(ast, ttl: ttl) do
+    quote do
+      unquote(ast)
+      |> Dagger.Function.with_cache_policy(Dagger.FunctionCachePolicy.default(),
+        time_to_live: unquote(ttl)
+      )
+    end
+  end
+
+  defp apply_cache_ast(ast, _), do: ast
+
+  # Normalize raw @doc attribute value.
+  # Returns {doc_string_or_nil, deprecated_reason_or_nil}.
+  defp normalize_doc_attr(nil), do: {nil, nil}
+  defp normalize_doc_attr(false), do: {nil, nil}
+  defp normalize_doc_attr({_line, doc}) when is_binary(doc), do: {doc, nil}
+  defp normalize_doc_attr({_line, opts}) when is_list(opts),
+    do: {opts[:doc], opts[:deprecated]}
+  defp normalize_doc_attr(doc) when is_binary(doc), do: {doc, nil}
+  defp normalize_doc_attr(opts) when is_list(opts), do: {opts[:doc], opts[:deprecated]}
+  defp normalize_doc_attr(_), do: {nil, nil}
+
+  # Normalize raw @deprecated attribute value.
+  defp normalize_deprecated_attr(nil), do: nil
+  defp normalize_deprecated_attr(reason) when is_binary(reason), do: reason
+  defp normalize_deprecated_attr(_), do: nil
 
   defmacro __using__(opts) do
     name = opts[:name]
@@ -198,6 +460,13 @@ defmodule Dagger.Mod.Object do
       Module.register_attribute(__MODULE__, :function, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :field, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :cache, accumulate: false, persist: true)
+      # Stores {fn_name, has_self?, arg_defs, return_def, cache, doc, deprecated}
+      # captured at defn expansion time so @doc/@deprecated are available before
+      # the inner `def` clears them.
+      Module.register_attribute(__MODULE__, :function_compile_data, accumulate: true)
+      # Store the Dagger object name for use in @before_compile.
+      Module.register_attribute(__MODULE__, :object_name, accumulate: false)
+      @object_name unquote(name)
 
       @before_compile Dagger.Mod.Object
 
@@ -236,8 +505,17 @@ defmodule Dagger.Mod.Object do
     return_def = compile_typespec!(return)
 
     quote do
-      cache_attr =
-        Module.get_attribute(__MODULE__, :cache)
+      # Capture @doc, @deprecated, @cache BEFORE the inner `def` (inside
+      # Defn.define) clears them.  These are evaluated at module-compile time,
+      # in the order they appear in the module body, so @doc is still set here.
+      cache_attr = Module.get_attribute(__MODULE__, :cache)
+      doc_attr = Module.get_attribute(__MODULE__, :doc)
+      deprecated_attr = Module.get_attribute(__MODULE__, :deprecated)
+
+      @function_compile_data {unquote(name), unquote(has_self?),
+                               unquote(Macro.escape(arg_defs)),
+                               unquote(Macro.escape(return_def)), cache_attr,
+                               doc_attr, deprecated_attr}
 
       @function {unquote(name),
                  %Dagger.Mod.Object.FunctionDef{

--- a/sdk/elixir/lib/dagger/mod/object/type_def.ex
+++ b/sdk/elixir/lib/dagger/mod/object/type_def.ex
@@ -58,7 +58,11 @@ defmodule Dagger.Mod.Object.TypeDef do
         end
 
       :enum ->
-        Dagger.Mod.Module.define_enum(dag, module)
+        if function_exported?(module, :__register__, 1) do
+          module.__register__(dag)
+        else
+          Dagger.Mod.Module.define_enum(dag, module)
+        end
     end
   end
 end

--- a/sdk/elixir/lib/dagger/mod/registry.ex
+++ b/sdk/elixir/lib/dagger/mod/registry.ex
@@ -5,8 +5,47 @@ defmodule Dagger.Mod.Registry do
 
   def register(root_module) do
     root_module
-    |> traverse()
+    |> collect_all([])
     |> Enum.reduce(%__MODULE__{}, &put_module(&2, &1))
+  end
+
+  # Collect root_module and all its transitive dependencies.
+  # Uses the compile-time __dependencies__/0 when available; falls back to the
+  # legacy runtime traversal otherwise.
+  defp collect_all(module, visited) do
+    if module in visited do
+      []
+    else
+      visited = [module | visited]
+
+      direct_deps =
+        if function_exported?(module, :__dependencies__, 0) do
+          module.__dependencies__()
+        else
+          runtime_deps(module)
+        end
+
+      transitive =
+        Enum.flat_map(direct_deps, fn dep -> collect_all(dep, visited) end)
+
+      [module | transitive]
+      |> Enum.uniq()
+    end
+  end
+
+  # Legacy: derive direct dependencies by inspecting FunctionDef structs.
+  defp runtime_deps(module) do
+    if function_exported?(module, :__object__, 1) do
+      module.__object__(:functions)
+      |> Enum.flat_map(fn {_, fun_def} ->
+        arg_modules = collect_enums_from_funs(fun_def)
+        ret_modules = if object?(fun_def.return), do: [fun_def.return], else: []
+        arg_modules ++ ret_modules
+      end)
+      |> Enum.uniq()
+    else
+      []
+    end
   end
 
   def put_module(%__MODULE__{} = registry, module) when is_atom(module) do
@@ -35,30 +74,6 @@ defmodule Dagger.Mod.Registry do
       nil -> raise "Cannot find `#{name}` in the registry."
       module -> module
     end
-  end
-
-  defp traverse(root_module) do
-    root_module.__object__(:functions)
-    |> traverse([root_module])
-  end
-
-  defp traverse([], modules), do: modules |> List.flatten() |> Enum.uniq() |> Enum.reverse()
-
-  defp traverse([{_, fun_def} | funs], modules) do
-    enum_modules = collect_enums_from_funs(fun_def)
-
-    ret_module = fun_def.return
-
-    additional_modules =
-      if object?(ret_module) and ret_module not in modules do
-        traverse(ret_module)
-      else
-        []
-      end
-
-    modules_to_add = enum_modules ++ additional_modules
-
-    traverse(funs, [modules_to_add | modules])
   end
 
   defp collect_enums_from_funs(fun_def) do


### PR DESCRIPTION
Convert module/function/enum registration from runtime traversal to
compile-time generation:

- `use Dagger.Mod.Enum` now generates `__register__/1` (builds TypeDef
  directly from pre-computed member data) and `__dependencies__/0 => []`
- `defn` macro captures doc/deprecated/cache attrs before `def` clears
  them, accumulating into `@function_compile_data`
- `@before_compile` in `Dagger.Mod.Object` generates `__register__/1`
  (full TypeDef construction with fields, functions, constructor, args,
  cache policies, descriptions) and `__dependencies__/0` (pre-computed
  list of user-defined object/enum dependencies)
- `Registry.register/1` uses `__dependencies__/0` when available,
  falling back to runtime `FunctionDef` traversal for legacy modules
- `Dagger.Mod.Module.define/3` and `TypeDef.define/3` use `__register__/1`
  when available, falling back to the existing runtime define_object/
  define_enum paths

https://claude.ai/code/session_01AJTBsnMvLqQ5JRtQXGeGm6